### PR TITLE
Updating README.md to add jilayton as a contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 [cd-public](https://cd-public.github.io/)
 ## Contributors
 [Zagreb](https://zagreb-ethf23.github.io/)
+[jilayton](https://jilayton.github.io/)


### PR DESCRIPTION
Jilayton adding themself as a contributor on 1/22/2024 to the eths24 class page of one Professor Calvin. I added a pseudonym and a link to my personal webpage in the contributors section, matching the format provided by the repository manager.